### PR TITLE
Pointer to Reference fix

### DIFF
--- a/rmw_coredx_cpp/src/functions.hpp
+++ b/rmw_coredx_cpp/src/functions.hpp
@@ -420,7 +420,7 @@ wait(const char * implementation_identifier,
     else
       fprintf(stderr, "waitset: active: read_cond: %p\n", read_condition);
 #endif
-    DDS_ReturnCode_t retcode = dds_waitset->detach_condition(read_condition);
+    DDS_ReturnCode_t retcode = dds_waitset->detach_condition(*read_condition);
     if (retcode != DDS_RETCODE_OK) {
       RMW_SET_ERROR_MSG("Failed to get detach condition from waitset");
     }
@@ -455,7 +455,7 @@ wait(const char * implementation_identifier,
         if (!(j < active_conditions.size())) {
           guard_conditions->guard_conditions[i] = 0;
         } 
-        DDS_ReturnCode_t retcode = dds_waitset->detach_condition(guard_condition);
+        DDS_ReturnCode_t retcode = dds_waitset->detach_condition(*guard_condition);
         if (retcode != DDS_RETCODE_OK) {
           RMW_SET_ERROR_MSG("Failed to get detach condition from waitset");
         }


### PR DESCRIPTION
Compile error in gcc (Ubuntu 16.04, gcc 5.4) in conversion of
DDS::Condition* to DDS::Cnodition&