### PR TITLE
use string_array from c_utilities

### DIFF
--- a/rmw_coredx_cpp/CMakeLists.txt
+++ b/rmw_coredx_cpp/CMakeLists.txt
@@ -45,11 +45,13 @@ if(NOT rosidl_typesupport_coredx_cpp_FOUND)
   return()
 endif()
 
+find_package(c_utilities REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rosidl_generator_c REQUIRED)
 find_package(rosidl_generator_cpp REQUIRED)
 
 ament_export_dependencies(
+  c_utilities
   rmw
   rosidl_generator_c
   rosidl_generator_cpp
@@ -64,6 +66,7 @@ register_rmw_implementation(
 
 add_library(rmw_coredx_cpp SHARED src/functions.cpp)
 ament_target_dependencies(rmw_coredx_cpp
+  "c_utilities"
   "rmw"
   "rosidl_generator_c"
   "rosidl_generator_cpp"

--- a/rmw_coredx_cpp/package.xml
+++ b/rmw_coredx_cpp/package.xml
@@ -12,6 +12,7 @@
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
+  <build_depend>c_utilities</build_depend>
   <build_depend>coredx_cmake_module</build_depend>
   <build_depend>libdds_cpp</build_depend>
   <build_depend>rmw</build_depend>

--- a/rmw_coredx_cpp/src/functions.cpp
+++ b/rmw_coredx_cpp/src/functions.cpp
@@ -102,7 +102,7 @@
     
 
 
-const char * toc_coredx_identifier = "coredx_static";
+const char * toc_coredx_identifier = "rmw_coredx_cpp";
 
 /* ************************************************
  */
@@ -2117,8 +2117,9 @@ rmw_destroy_topic_names_and_types( rmw_topic_names_and_types_t * topic_names_and
 /* ************************************************
  */
 rmw_ret_t
-rmw_get_node_names(const rmw_node_t * node,
-                   rmw_string_array_t * node_names)
+rmw_get_node_names(
+  const rmw_node_t * node,
+  utilities_string_array_t * node_names)
 {
   if (!node) {
     RMW_SET_ERROR_MSG("node handle is null");
@@ -2169,33 +2170,6 @@ rmw_get_node_names(const rmw_node_t * node,
   return RMW_RET_OK;
 }
 
-/* ************************************************
- */
-rmw_ret_t
-rmw_destroy_node_names(
-  rmw_string_array_t * node_names)
-{
-  if (!node_names)
-    {
-      RMW_SET_ERROR_MSG("node_names handle is null");
-      return RMW_RET_ERROR;
-    }
-  for (size_t i = 0; i < node_names->size; ++i)
-    {
-      rmw_free(node_names->data[i]);
-      node_names->data[i] = nullptr;
-    }
-  if (node_names->data)
-    {
-      rmw_free(node_names->data);
-      node_names->data = nullptr;
-    }
-  node_names->size = 0;
-  return RMW_RET_OK;
-}
-
-/* ************************************************
- */
 rmw_ret_t
 rmw_count_publishers( const rmw_node_t * node,
                       const char       * topic_name,


### PR DESCRIPTION
We are in the process of refactoring and deduplicating code. This is updating the rmw functions signatures that changed since my last PR. There will likely be a follow up in the next few days once https://github.com/ros2/c_utilities/pull/16 and connected PRs get merged.

Also this PR changed the name of the `toc_coredx_identifier` to `rmw_coredx_cpp` so that it's consitent with the other rmw_implementation and can be integrated in our test suite easily