### PR TITLE
use rmw_coredx_process_topic_name to strip the slashes

### DIFF
--- a/rmw_coredx_cpp/src/rmw_count_publishers.cpp
+++ b/rmw_coredx_cpp/src/rmw_count_publishers.cpp
@@ -29,6 +29,7 @@
 #include "rmw_coredx_cpp/identifier.hpp"
 #include "rmw_coredx_types.hpp"
 #include "util.hpp"
+#include "names.hpp"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -68,8 +69,12 @@ rmw_count_publishers( const rmw_node_t * node,
     return RMW_RET_ERROR;
   }
 
+  char * topic_str     = nullptr;
+  char * partition_str = nullptr;
+  rmw_coredx_process_topic_name(topic_name, false, &topic_str, &partition_str);
+
   const auto & topic_names_and_types = node_info->publisher_listener->topic_names_and_types;
-  auto it = topic_names_and_types.find(topic_name);
+  auto it = topic_names_and_types.find(topic_str);
   if (it == topic_names_and_types.end()) {
     *count = 0;
   } else {

--- a/rmw_coredx_cpp/src/rmw_count_subscribers.cpp
+++ b/rmw_coredx_cpp/src/rmw_count_subscribers.cpp
@@ -29,6 +29,7 @@
 #include "rmw_coredx_cpp/identifier.hpp"
 #include "rmw_coredx_types.hpp"
 #include "util.hpp"
+#include "names.hpp"
 
 #if defined(__cplusplus)
 extern "C" {
@@ -68,8 +69,12 @@ rmw_count_subscribers( const rmw_node_t * node,
     return RMW_RET_ERROR;
   }
 
+  char * topic_str     = nullptr;
+  char * partition_str = nullptr;
+  rmw_coredx_process_topic_name(topic_name, false, &topic_str, &partition_str);
+
   const auto & topic_names_and_types = node_info->subscriber_listener->topic_names_and_types;
-  auto it = topic_names_and_types.find(topic_name);
+  auto it = topic_names_and_types.find(topic_str);
   if (it == topic_names_and_types.end()) {
     *count = 0;
   } else {


### PR DESCRIPTION
If we don't strip the slashes, then the count wont be correct for the ros2 dynamic_bridge or probably anywhere, since coredx stores topic names without slashes.