### PR TITLE
Altered generated ros type names to be compatible with ros1 bridge

### DIFF
--- a/rmw_coredx_cpp/CMakeLists.txt
+++ b/rmw_coredx_cpp/CMakeLists.txt
@@ -17,6 +17,12 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rmw_coredx_cpp)
 
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+
 if(NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
 endif()
@@ -45,6 +51,7 @@ if(NOT rosidl_typesupport_coredx_cpp_FOUND)
   return()
 endif()
 
+find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rosidl_generator_c REQUIRED)
@@ -53,6 +60,7 @@ find_package(rosidl_generator_cpp REQUIRED)
 include_directories(include)
 
 ament_export_dependencies(
+  rcpputils
   rcutils
   rmw
   rosidl_generator_c
@@ -124,6 +132,7 @@ add_library(rmw_coredx_cpp SHARED
   src/util.cpp
   )
 ament_target_dependencies(rmw_coredx_cpp
+  "rcpputils"
   "rcutils"
   "rmw"
   "rosidl_generator_c"

--- a/rmw_coredx_cpp/package.xml
+++ b/rmw_coredx_cpp/package.xml
@@ -29,6 +29,7 @@
   <build_export_depend>rosidl_typesupport_coredx_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_coredx_cpp</build_export_depend>
 
+  <exec_depend>rcpputils</exec_depend>
   <exec_depend>rcutils</exec_depend>
   <exec_depend>rmw</exec_depend>
 

--- a/rmw_coredx_cpp/src/rmw_create_publisher.cpp
+++ b/rmw_coredx_cpp/src/rmw_create_publisher.cpp
@@ -96,7 +96,7 @@ rmw_create_publisher( const rmw_node_t        * node,
     return NULL;
   }
   
-  std::string type_name = _create_type_name(callbacks, "msg");
+  std::string type_name = _create_type_name(callbacks, "");
   std::string tmp_topic_name;
   if ( !qos_policies->avoid_ros_namespace_conventions ) {
     tmp_topic_name = std::string(ros_topic_prefix) + topic_name;

--- a/rmw_coredx_cpp/src/rmw_create_subscription.cpp
+++ b/rmw_coredx_cpp/src/rmw_create_subscription.cpp
@@ -92,7 +92,7 @@ rmw_create_subscription( const rmw_node_t        * node,
     return NULL;
   }
 
-  std::string type_name = _create_type_name(callbacks, "msg");
+  std::string type_name = _create_type_name(callbacks, "");
   std::string tmp_topic_name;
   if ( !qos_policies->avoid_ros_namespace_conventions ) {
     tmp_topic_name = std::string(ros_topic_prefix) + topic_name;

--- a/rmw_coredx_cpp/src/util.hpp
+++ b/rmw_coredx_cpp/src/util.hpp
@@ -51,7 +51,7 @@ _create_type_name(
 {
   return
     std::string(callbacks->package_name) +
-    "::" + sep + "::dds_::" + callbacks->message_name + "_";
+    (sep.empty() ? "" : "::") + sep + "::dds_::" + callbacks->message_name + "_";
 }
 
 #define RMW_COREDX_EXTRACT_MESSAGE_TYPESUPPORT(TYPE_SUPPORTS, TYPE_SUPPORT) \


### PR DESCRIPTION
I was trying to test the ros1 bridge with the core dx middleware and realised the type names didn't match.
The coredx was producing type names like 'package::msg/MsgName' rather than 'package/msg/MsgName'.

I had to set the c++ standard to c++14, as that I included rcpputils/find_and_replace.hpp in mw_coredx_cpp/src/rmw_get_topic_names_and_types.cpp.

I set the separator for _create_type_name to "" rather than "msg", because the "msg" string was already in the package name.


