### PR TITLE
Fix type format of rmw_get_topic_names_and_types

### DIFF
--- a/rmw_coredx_cpp/src/rmw_get_topic_names_and_types.cpp
+++ b/rmw_coredx_cpp/src/rmw_get_topic_names_and_types.cpp
@@ -53,7 +53,7 @@ _demangle_if_ros_topic(const std::string & topic_name)
 static std::string
 _demangle_if_ros_type(const std::string & dds_type_string)
 {
-  std::string substring = "::msg::dds_::";
+  std::string substring = "::msg::msg::dds_::";
   size_t substring_position = dds_type_string.find(substring);
   if (
     dds_type_string[dds_type_string.size() - 1] == '_' &&

--- a/rmw_coredx_cpp/src/rmw_get_topic_names_and_types.cpp
+++ b/rmw_coredx_cpp/src/rmw_get_topic_names_and_types.cpp
@@ -53,7 +53,7 @@ _demangle_if_ros_topic(const std::string & topic_name)
 static std::string
 _demangle_if_ros_type(const std::string & dds_type_string)
 {
-  std::string substring = "::msg::msg::dds_::";
+  std::string substring = "::msg::dds_::";
   size_t substring_position = dds_type_string.find(substring);
   if (
     dds_type_string[dds_type_string.size() - 1] == '_' &&

--- a/rmw_coredx_cpp/src/util.hpp
+++ b/rmw_coredx_cpp/src/util.hpp
@@ -50,8 +50,7 @@ _create_type_name(
   const std::string & sep)
 {
   return
-    std::string(callbacks->package_name) +
-    "::" + sep + "::dds_::" + callbacks->message_name + "_";
+    std::string(callbacks->package_name) + "::dds_::" + callbacks->message_name + "_";
 }
 
 #define RMW_COREDX_EXTRACT_MESSAGE_TYPESUPPORT(TYPE_SUPPORTS, TYPE_SUPPORT) \


### PR DESCRIPTION
When running a talker, then running `ros2 topic list -t` I would see the topic types like `/chatter [std_msgs::msg/String]` This would cause problems in other places, like when running `ros2 bag record -a`.

added extra '::msg' so that the returned format is pkg/type instead of pkg::msg/type.

